### PR TITLE
feat: add serde feature for (de)serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "mrtd"
 version = "0.5.1"
 description = "Parser for machine-readable travel documents (MRTD)"
-authors = ["António Marques <me@antoniomarques.eu>", "Metin Binbir <binbir.metin@hotmail.com>"]
+authors = [
+  "António Marques <me@antoniomarques.eu>",
+  "Metin Binbir <binbir.metin@hotmail.com>",
+]
 edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/asmarques/mrtd"
@@ -10,7 +13,11 @@ readme = "README.md"
 keywords = ["mrtd", "icao", "mrz", "passport", "travel"]
 categories = ["parser-implementations", "encoding"]
 
+[features]
+serde = ["dep:serde", "chrono/serde"]
+
 [dependencies]
 chrono = "0.4"
 regex = "1"
 lazy_static = "1.1"
+serde = { version = "1", optional = true, features = ["derive"] }

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,7 +1,14 @@
 use chrono::NaiveDate;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Travel document
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "snake_case", tag = "type")
+)]
 pub enum Document {
     /// Passport
     Passport(Passport),
@@ -11,6 +18,11 @@ pub enum Document {
 
 /// Gender
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum Gender {
     /// Male
     Male,
@@ -22,6 +34,7 @@ pub enum Gender {
 
 /// Passport
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Passport {
     /// Country (ISO 3166-1 code)
     pub country: String,
@@ -43,6 +56,7 @@ pub struct Passport {
 
 /// Identity Card
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IdentityCard {
     /// Country (ISO 3166-1 code)
     pub country: String,


### PR DESCRIPTION
This feature is entirely optional, and is disabled by default.
`rename_all = "snake_case"` and `tag = "type"` are just set because I prefer that, but if you want something else that's fine as well.